### PR TITLE
Add gatsby-remark-vscode to the project

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -23,6 +23,13 @@ module.exports = {
           mode: `light`,
         },
         ignore: ["README.md", "LICENSE.md"],
+        gatsbyRemarkPlugins: [
+          {
+            resolve: "gatsby-remark-vscode",
+            // OPTIONAL
+            options: {}
+          }
+        ]
       },
     },
 

--- a/docs/src/gatsby-theme-docz/components/index.js
+++ b/docs/src/gatsby-theme-docz/components/index.js
@@ -1,0 +1,11 @@
+import * as headings from "gatsby-theme-docz/src/components/Headings";
+import { Layout } from "gatsby-theme-docz/src/components/Layout";
+import { Playground } from "gatsby-theme-docz/src/components/Playground";
+import { Props } from "gatsby-theme-docz/src/components/Props";
+
+export default {
+  ...headings,
+  playground: Playground,
+  layout: Layout,
+  props: Props
+};

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -7,4 +7,20 @@ route: /
 
 ## Sample code
 
-Bla bla bla.
+```js
+// Example code bla-bla
+import React from "react"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const NotFoundPage = () => (
+  <Layout>
+    <SEO title="404: Not found" />
+    <h1>NOT FOUND</h1>
+    <p>You just hit a route that doesn't exist... the sadness.</p>
+  </Layout>
+)
+
+export default NotFoundPage
+```


### PR DESCRIPTION
## Add gatsby-remark-vscode to the project
`docs/src/gatsby-theme-docz/components/index.js` - to tell Docz not try to highlight Code and Pre blocks
`docs/gatsby-config.js` - add config. since this is not clean Docz installation we have to use this file instead
`docs/src/pages/index.md` - sample of the code block, you should see vscode styles